### PR TITLE
Only check if provided autoDownloadModelName already exist

### DIFF
--- a/src/autoDownloadModel.ts
+++ b/src/autoDownloadModel.ts
@@ -21,12 +21,11 @@ export default async function autoDownloadModel(
 	try {
 		const modelDirectory = path.join(__dirname, '..', 'cpp', 'whisper.cpp', 'models')
 		shell.cd(modelDirectory)
+		const modelAlreadyExist = fs.existsSync(path.join(modelDirectory, autoDownloadModelName));
 
-		const existingModels = MODELS.filter(model => fs.existsSync(path.join(modelDirectory, model)))
-
-		if (existingModels.length > 0) {
+		if (modelAlreadyExist) {
 			if (verbose) {
-				console.log('[Nodejs-whisper] Models already exist. Skipping download.')
+				console.log(`[Nodejs-whisper] ${autoDownloadModel} already exist. Skipping download.`)
 			}
 			return 'Models already exist. Skipping download.'
 		}


### PR DESCRIPTION
Instead of checking if any model already exist when being given a autoDownloadModelName, perhaps it would be better to check if the one provided already exists. 

This would allow for more than one model existing. 