### PR TITLE
fix: add missing downloadModel function call for CLI command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nodejs-whisper",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "Node bindings for OpenAI's Whisper. Optimized for CPU.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -63,7 +63,7 @@
 		"typescript": "^5.1.6"
 	},
 	"files": [
-    "dist/",
-    "cpp/"
-]
+		"dist/",
+		"cpp/"
+	]
 }

--- a/src/downloadModel.ts
+++ b/src/downloadModel.ts
@@ -116,3 +116,7 @@ async function downloadModel(logger = console) {
 		return error
 	}
 }
+downloadModel().catch(error => {
+	console.error('Failed to download:', error)
+	process.exit(1)
+})


### PR DESCRIPTION
- Fixes issue where 'npx nodejs-whisper download' would do nothing
- CLI command now properly executes the download workflow