### PR TITLE
fix: use platform-appropriate script path in downloader check on Windows

### DIFF
--- a/src/downloadModel.ts
+++ b/src/downloadModel.ts
@@ -81,13 +81,17 @@ async function downloadModel(logger: Logger = console) {
 | large-v3-turbo | 1.5 GB | ~2.6 GB |
 `)
 
-		if (!shell.which('./download-ggml-model.sh')) {
-			throw '[Nodejs-whisper] Error: Downloader not found.\n'
-		}
+		  const downloaderScript = process.platform === 'win32'
+		      ? 'download-ggml-model.cmd'
+		      : './download-ggml-model.sh'
+		
+		  if (!shell.which(downloaderScript)) {
+		      throw '[Nodejs-whisper] Error: Downloader not found.\n'
+		  }
 
 		const modelName = await askForModel()
 
-		let scriptPath = './download-ggml-model.sh'
+		let scriptPath = downloaderScript
 		if (process.platform === 'win32') scriptPath = 'download-ggml-model.cmd'
 
 		shell.chmod('+x', scriptPath)


### PR DESCRIPTION
Fixes #242

## How to test

  ### On Windows

  1. Clone the repo and run `npm install`
  2. Run `npx nodejs-whisper download` **before** this fix (checkout `main`)
     - Expected: immediately throws `[Nodejs-whisper] Error: Downloader not found.`
  3. Apply the fix (checkout this branch)
  4. Run `npx nodejs-whisper download` again
     - Expected: model selection prompt appears, download proceeds, cmake build runs

  ### Simulating the bug on any platform

  The `which()` check can be tested in isolation:

  ```js
  const shell = require('shelljs')

  // Simulates what the old code does on Windows
  console.log(shell.which('./download-ggml-model.sh')) // null on Windows

  // Simulates what the fix does on Windows
  console.log(shell.which('download-ggml-model.cmd'))  // returns path on Windows
  ```

  Run this inside cpp/whisper.cpp/models/ where the scripts live.

  ### Unit-level check (any platform)

  You can also force the Windows branch by temporarily hardcoding process.platform === 'win32' to true   in the fixed code and confirming which() resolves download-ggml-model.cmd correctly.

## Note
I later hit a `libgomp-1.dll` crash you hit as a downstream consequence of  this bug: because the download/build never ran, an old MinGW-linked binary was sitting there from a  prior partial build attempt. The real first failure was this which() check. Looking to fix this bug first before filing the libgomp one as a separate issue + PR after this one merges.
